### PR TITLE
修复安装报错

### DIFF
--- a/install.sql
+++ b/install.sql
@@ -48,7 +48,7 @@ CREATE TABLE `cloud_white` (
 DROP TABLE IF EXISTS `cloud_record`;
 CREATE TABLE `cloud_record` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `ip` varchar(200) NOT NULL,
+  `ip` varchar(64) NOT NULL,
   `addtime` datetime NOT NULL,
   `usetime` datetime NOT NULL,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
MySQL 5.6 安装报错：Specified key was too long; max key length is 767 bytes
即使是 IPv6 也没必要给那么大。