### PR TITLE
feat: support get_malicious_ip for bt_waf

### DIFF
--- a/app/controller/Api.php
+++ b/app/controller/Api.php
@@ -2,6 +2,7 @@
 namespace app\controller;
 
 use think\facade\Db;
+use think\facade\Cache;
 use app\BaseController;
 use app\lib\Plugins;
 
@@ -464,6 +465,40 @@ class Api extends BaseController
     public function get_ssl_list(){
         $data = bin2hex('[]');
         return json(['status'=>true, 'msg'=>'', 'data'=>$data]);
+    }
+
+    //获取堡塔云WAF恶意IP库
+    public function get_malicious_ip_list()
+    {
+        $cacheKey = 'malicious_ip_list';
+    
+        // 尝试从缓存获取
+        if (Cache::has($cacheKey)) {
+            return json(json_decode(Cache::get($cacheKey), true));
+        }
+        $url = 'https://api.bt.cn/bt_waf/get_malicious_ip';
+        $postData = json_encode([
+            'x_bt_token' => 'MzI3YjAzOGQ3Yjk3NjUxYjVlMDkyMGFm'
+        ]);
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Content-Length: ' . strlen($postData)
+        ]);
+
+        $response = curl_exec($ch);
+        if (curl_errno($ch)) {
+            return json(['status'=>true, 'msg'=>'', 'data'=>$data]);
+        }
+        curl_close($ch);
+        Cache::set($cacheKey, $response, 86400); //缓存一天
+
+        return json(json_decode($response, true));
     }
 
     public function return_success(){

--- a/route/app.php
+++ b/route/app.php
@@ -18,7 +18,7 @@ Route::post('/Auth/GetBindCode', 'api/return_error');
 Route::post('/auth/GetUserGiveAway', 'api/get_user_give_away');
 Route::any('/bt_monitor/update_history', 'api/btm_update_history');
 Route::any('/bt_monitor/latest_version', 'api/btm_latest_version');
-Route::any('/bt_waf/get_malicious_ip', 'api/get_ssl_list');
+Route::any('/bt_waf/get_malicious_ip', 'api/get_malicious_ip_list');
 Route::any('/bt_waf/daily_count_v2', 'api/get_ssl_list');
 Route::any('/bt_waf/latest_version', 'api/btwaf_latest_version');
 


### PR DESCRIPTION
这个`x_bt_token`是写死在`BT-WAF`程序里的...一下子没绷住
没有复用 `app/lib` 里的 `curl` 函数，因为看起来没有给 `BT-WAF` 用的 （
不会 PHP, 边问 AI 边写的 （
Closes #263